### PR TITLE
Document LangChain `@tool` decorator exception in tools guidance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,8 @@
 - [langgraph/backend] Replace backend RULES references with map-driven contracts and split platform guidance into `.shared/platform.yml`.
 - [langgraph/backend] Expand platform map metadata with component consumers.
 - [docs] Align langgraph AGENTS guidance to rely on local component contracts instead of backend-specific references.
+- [docs] Document the intentional `@tool` decorator exception in backend architectural reasoning.
+- [docs] Note the intentional `@tool` decorator exception in the tools instruction surface.
 - [langgraph/backend] Disable HILP routing in ambiguity preflight so clarification always uses the internal agent loop.
 - [langgraph/backend] Validate SageState updates in ambiguity supervisor, retrieval, phase supervisor, and external clarification nodes.
 - [langgraph/backend] Remove legacy `graphs/phases` and tests directories after the subgraph layout move.

--- a/langgraph/backend/README.md
+++ b/langgraph/backend/README.md
@@ -17,6 +17,12 @@ composed without importing or constructing concrete dependencies at import time.
 supports fast unit tests, controlled integration tests, and clearer boundaries between
 orchestration and implementation.
 
+### Intentional exception: LangChain `@tool` usage
+The tools layer currently uses LangChain's `@tool` decorator for clarity and ecosystem
+alignment, even though it constructs tool instances at import time. This is a known
+exception to the DI-first, no import-time construction preference and is tracked for
+future refinement.
+
 ### Contract-driven platform rules
 The platform contracts in `app/platform/contract/` make behavioral guarantees executable
 and testable (state ownership, tool allowlists, prompt requirements, etc.). This keeps

--- a/langgraph/backend/app/tools/AGENTS.md
+++ b/langgraph/backend/app/tools/AGENTS.md
@@ -4,6 +4,7 @@ This file is the **primary** instruction surface when editing `app/tools/**`.
 
 ## Scope
 - Tools stay typed, stateless, allowlist-driven, and deterministic.
+- Intentional exception: tools use LangChain's `@tool` decorator today for clarity and ecosystem alignment, even though it constructs tool instances at import time. Treat this as a documented exception to DI-first guidance and revisit when tooling factories are introduced.
 - Use `component_types.tools.contracts` in `../../.shared/components.yml` to find enforceable contracts and rule snippets.
 
 ## References


### PR DESCRIPTION
### Motivation
- Surface a known, intentional exception to the DI-first guidance where LangChain's `@tool` constructs tool instances at import time so reviewers understand the tradeoff. 
- Make the tools instruction surface explicit about current ecosystem-driven choices to reduce tribal knowledge and speed review decisions. 
- Keep the project changelog accurate by recording the documentation update.

### Description
- Add an explicit note to `langgraph/backend/app/tools/AGENTS.md` explaining the intentional exception for LangChain's `@tool` decorator. 
- Add a corresponding line to `CHANGELOG.md` documenting the documentation update. 
- Inspected `langgraph/backend/app/platform/config/file_loader.py` and confirmed `FileLoader._is_dev_mode()` performs a lazy environment check instead of import-time evaluation.

### Testing
- No automated tests were run because this is a documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6962d90aa818832fa8421975d377703c)